### PR TITLE
[Bugfix] Handle monorepos and workspace dependencies

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,27 +3,39 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { exec } from "node:child_process";
 
+type Dependencies = { [key: string]: string }; 
+
 interface PackageJson {
   name?: string;
   version?: string;
   description?: string;
   main?: string;
   scripts?: { [key: string]: string };
-  dependencies?: { [key: string]: string };
-  devDependencies?: { [key: string]: string };
-  peerDependencies?: { [key: string]: string };
-  optionalDependencies?: { [key: string]: string };
+  dependencies?: Dependencies;
+  devDependencies?: Dependencies;
+  peerDependencies?: Dependencies;
+  optionalDependencies?: Dependencies;
   [key: string]: unknown;
 }
 
-function detectPackageManager(workspaceFolder: string): "npm" | "yarn" | "pnpm" {
+function detectPackageManager(workspaceFolder: string): "npm" | "yarn" | "pnpm" | undefined {
   if (fs.existsSync(path.join(workspaceFolder, "yarn.lock"))) {
     return "yarn";
   }
   if (fs.existsSync(path.join(workspaceFolder, "pnpm-lock.yaml"))) {
     return "pnpm";
   }
-  return "npm";
+  if (fs.existsSync(path.join(workspaceFolder, "package-lock.json"))) {
+    return "npm";
+  }
+  return undefined;
+}
+
+function fmtDeps(deps?: Dependencies) {
+  if (!deps) {
+    return [];
+  }
+  return Object.keys(deps).filter((pkg) => !deps[pkg].includes("workspace:"));
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -42,10 +54,10 @@ export function activate(context: vscode.ExtensionContext) {
 
       try {
         const packageJson: PackageJson = JSON.parse(fileContent);
-        const dependencies = Object.keys(packageJson.dependencies || {});
-        const devDependencies = Object.keys(packageJson.devDependencies || {});
-        const optionalDependencies = Object.keys(packageJson.optionalDependencies || {});
-        const peerDependencies = Object.keys(packageJson.peerDependencies || {});
+        const dependencies = fmtDeps(packageJson.dependencies);
+        const devDependencies = fmtDeps(packageJson.devDependencies);
+        const optionalDependencies = fmtDeps(packageJson.optionalDependencies);
+        const peerDependencies = fmtDeps(packageJson.peerDependencies);
         const allPackages = [
           ...dependencies.map(pkg => `dependency: ${pkg}`),
           ...devDependencies.map(pkg => `devDependency: ${pkg}`),
@@ -58,14 +70,28 @@ export function activate(context: vscode.ExtensionContext) {
           return;
         }
 
+        let monorepo = false;
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+        const cwd = path.dirname(filePath);
 
         if (!workspaceFolder) {
           vscode.window.showErrorMessage("No workspace folder found.");
           return;
         }
 
-        const packageManager = detectPackageManager(workspaceFolder);
+        const packageManager = (() => {
+          const _pkgManager = detectPackageManager(cwd);
+          if (!_pkgManager) {
+            monorepo = true;
+            return detectPackageManager(workspaceFolder);
+          }
+          return _pkgManager;
+        })();
+
+        if (!packageManager) {
+          vscode.window.showErrorMessage("No package manager lock file found in the workspace.");
+          return;
+        }
 
         const selectedPackages = await vscode.window.showQuickPick(allPackages, {
           canPickMany: true,
@@ -87,7 +113,8 @@ export function activate(context: vscode.ExtensionContext) {
           const uninstallCommand = `${managerRemoveCmd} ${packageName}`;
 
           await new Promise<void>((resolve, reject) => {
-            exec(uninstallCommand, { cwd: workspaceFolder }, (err, stdout, stderr) => {
+            // 2/21/2025 - hacky workaround for monorepos
+            exec(uninstallCommand, { cwd: monorepo ? cwd : workspaceFolder }, (err, stdout, stderr) => {
               if (err) {
                 vscode.window.showErrorMessage(`Error uninstalling ${packageName}: ${stderr}`);
                 reject(err);
@@ -99,6 +126,7 @@ export function activate(context: vscode.ExtensionContext) {
           });
         }
       } catch (error) {
+        console.error(error);
         vscode.window.showErrorMessage("Error parsing package.json.");
       }
     }


### PR DESCRIPTION
## Description
This pull request involves several enhancements and bug fixes to the `src/extension.ts` file, focusing on improving dependency management and handling monorepos. The key changes include the introduction of a `Dependencies` type, the addition of a utility function for filtering dependencies, and modifications to the package manager detection logic to support monorepos.

Improvements to dependency management:

* Introduced a new `Dependencies` type to simplify the `PackageJson` interface.
* Added a utility function `fmtDeps` to filter out workspace dependencies from the dependencies list.
* Updated the dependency extraction logic in the `activate` function to use the new `fmtDeps` function.

Enhancements for monorepo support:

* Modified the `detectPackageManager` function to return `undefined` if no package manager is found.
* Updated the package manager detection logic in the `activate` function to handle monorepos by checking both the current working directory and the workspace folder.
* Added a workaround to execute uninstall commands in the appropriate directory for monorepos.

Error handling improvements:

* Added a console error log for better debugging when parsing `package.json` fails.