### PR TITLE
[Feat] Add bun support and progress bar to show status of worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Alternatively, you can install it via the [Marketplace](https://marketplace.visu
 - **npm**
 - **yarn**
 - **pnpm**
+- **bun**
 
 The extension automatically detects which package manager you're using based on your project's `package.json`.
 


### PR DESCRIPTION
## Description
This pull request includes updates to support the `bun` package manager in addition to the existing package managers. The most important changes include modifications to the `detectPackageManager` function, updates to the uninstall command logic, and enhancements to the user interface for package uninstallation progress.

Support for `bun` package manager:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34): Added `bun` to the list of supported package managers.
* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L21-R21): Updated the `detectPackageManager` function to detect `bun` by checking for `bun.lock` and `bun.lockb` files. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L21-R21) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R31-R36)
* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R116-R142): Modified the uninstall command logic to include `bun remove` when the package manager is detected as `bun`.

User interface enhancements:

* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R116-R142): Added a progress notification for the package uninstallation process, providing feedback to the user on the status of each package being uninstalled.